### PR TITLE
Separate log_dir and ckpt_dir

### DIFF
--- a/core/getpoint/run_summarization.py
+++ b/core/getpoint/run_summarization.py
@@ -33,6 +33,7 @@ FLAGS = tf.app.flags.FLAGS
 
 # Where to find data
 tf.app.flags.DEFINE_string('data_path', '', 'Path expression to tf.Example datafiles. Can include wildcards to access multiple datafiles.')
+tf.app.flags.DEFINE_string('ckpt_dir', '', 'Directory that contains the ckpt files.')
 tf.app.flags.DEFINE_string('vocab_path', '', 'Path expression to text vocabulary file.')
 
 # Important settings
@@ -138,7 +139,7 @@ def convert_to_coverage_model():
   # load all non-coverage weights from checkpoint
   saver = tf.train.Saver([v for v in tf.global_variables() if "coverage" not in v.name and "Adagrad" not in v.name])
   print("restoring non-coverage variables...")
-  curr_ckpt = util.load_ckpt(saver, sess)
+  curr_ckpt = util.load_ckpt(saver, sess, FLAGS.ckpt_dir)
   print("restored.")
 
   # save this model and quit
@@ -231,7 +232,7 @@ def run_eval(model, batcher, vocab):
   best_loss = None  # will hold the best loss achieved so far
 
   while True:
-    _ = util.load_ckpt(saver, sess) # load a new checkpoint
+    _ = util.load_ckpt(saver, sess, FLAGS.ckpt_dir) # load a new checkpoint
     batch = batcher.next_batch() # get the next batch
 
     # run eval on the batch

--- a/core/getpoint/util.py
+++ b/core/getpoint/util.py
@@ -32,7 +32,7 @@ def load_ckpt(saver, sess, ckpt_dir=""):
   while True:
     try:
       latest_filename = "checkpoint_best" if ckpt_dir=="eval" else None
-      ckpt_dir = os.path.join(FLAGS.log_root, ckpt_dir)
+      ckpt_dir = os.path.join(FLAGS.ckpt_dir, ckpt_dir)
       ckpt_state = tf.train.get_checkpoint_state(ckpt_dir, latest_filename=latest_filename)
       tf.logging.info('Loading checkpoint %s', ckpt_state.model_checkpoint_path)
       saver.restore(sess, ckpt_state.model_checkpoint_path)


### PR DESCRIPTION
Currently the underlying model code uses log_dir as ckpt_dir. But this will
cause issue on OpenShift because log_dir is not supposed to be writable. This
separates these two dirs.